### PR TITLE
Badges

### DIFF
--- a/_articles/opening-your-project/develop-an-open-project-strategy-with-open-canvas.md
+++ b/_articles/opening-your-project/develop-an-open-project-strategy-with-open-canvas.md
@@ -36,7 +36,7 @@ Here’s more about the Open Canvas tool from its creator, Abby Cabunoc Mayes, D
 
 Here’s a sample of an Open Canvas created by Abby for Mozilla Science Lab’s Paper Badger Open Project.
 
-![](https://lh6.googleusercontent.com/Ia3HtZ6f0MRAcD2mDzhBVnow2DNNmUNbYMgulW3qPWJN1xdjOuMdLnhePaqAEHDy39ZFojXM2OtdI8uo3QcYaxvwTz3QM9al5YEBQtkwCKKVc6azrQ4b5DPWisPiXCVHEBt6lKnG)
+![](https://lh6.googleusercontent.com/Ia3HtZ6f0MRAcD2mDzhBVnow2DNNmUNbYMgulW3qPWJN1xdjOuMdLnhePaqAEHDy39ZFojXM2OtdI8uo3QcYaxvwTz3QM9al5YEBQtkwCKKVc6azrQ4b5DPWisPiXCVHEBt6lKnG)<!--- This is picturing Badges for Science; I like the cross marketing. Are there Badges for Open Leadership? --->
 
 ### Minimum Viable Product (MVP)
 


### PR DESCRIPTION
Funny, I was just thinking "Does it have this: https://badges.mozillascience.org/ "
Then I go back to the course to read & there's a picture:
line#39 ![](https://lh6.googleusercontent.com/Ia3HtZ6f0MRAcD2mDzhBVnow2DNNmUNbYMgulW3qPWJN1xdjOuMdLnhePaqAEHDy39ZFojXM2OtdI8uo3QcYaxvwTz3QM9al5YEBQtkwCKKVc6azrQ4b5DPWisPiXCVHEBt6lKnG)
&
https://groups.google.com/forum/#!forum/openbadges-dev ? that's not right.

https://openbadges.org/community/

Is there a criteria roadmap to get [it](https://github.com/mozilla/open-leadership-training-series) listed?
https://wiki.mozilla.org/Badges/Issuers